### PR TITLE
Make `FakeFile` respond to `read`

### DIFF
--- a/addon/test-helper.js
+++ b/addon/test-helper.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const DATA_URI = 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';
+
 function FakeFile(attrs) {
   this.id = Ember.generateGuid();
   attrs.plupload.total.size += attrs.size;
@@ -10,6 +12,10 @@ FakeFile.prototype = {
   upload(settings) {
     this.settings = settings;
     this.percent = 0;
+  },
+
+  read() {
+    return Ember.RSVP.resolve(DATA_URI);
   },
 
   respondWith(status, headers, body) {

--- a/tests/integration/components/pl-uploader-test.js
+++ b/tests/integration/components/pl-uploader-test.js
@@ -7,7 +7,12 @@ moduleForComponent('pl-uploader', {
 });
 
 test('addFiles test helper integration', function(assert) {
+  assert.expect(5);
+
   this.on('uploadIt', (file) => {
+    file.read().then((dataUri) => {
+      assert.ok(dataUri, 'file is readable with data URI');
+    });
     file.upload();
   });
 


### PR DESCRIPTION
When `FakeFile#read` is invoked, return an `RSVP` promise that returns
the data URI for a 1x1 transparent pixel.