### PR TITLE
Refactor how in progress drags are handeled.

### DIFF
--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -137,9 +137,7 @@ export default Ember.Component.extend({
     // Send up the pluploader object so the app implementing this component as has access to it
     var pluploader = queue.get('queues.firstObject');
     this.sendAction('onInitOfUploader', pluploader);
-
-    this._firstDragEnter = false;
-    this._secondDragEnter = false;
+    this._dragInProgress = false;
     this._invalidateDragData();
   },
 
@@ -181,22 +179,15 @@ export default Ember.Component.extend({
 
   dragData: null,
   enteredDropzone({ originalEvent: evt }) {
-    if (this._firstDragEnter) {
-      this._secondDragEnter = true;
-    } else {
-      this._firstDragEnter = true;
-      this.activateDropzone(evt);
+    if (this._dragInProgress === false) {
+        this._dragInProgress = true;
+        this.activateDropzone(evt);
     }
   },
 
   leftDropzone() {
-    if (this._secondDragEnter) {
-      this._secondDragEnter = false;
-    } else {
-      this._firstDragEnter = false;
-    }
-
-    if (!this._firstDragEnter && !this._secondDragEnter) {
+    if (this._dragInProgress === true) {
+      this._dragInProgress = false;
       this.deactivateDropzone();
     }
   },
@@ -215,7 +206,7 @@ export default Ember.Component.extend({
     sheet.css(`#${get(this, 'dropzone.id')} *`, null);
     Ember.run.scheduleOnce('render', sheet, 'applyStyles');
 
-    this._firstDragEnter = this._secondDragEnter = false;
+    this._dragInProgress = false;
     set(this, 'dragData', null);
   },
 


### PR DESCRIPTION
In one of our apps we were consistently getting two `dragenter` events but only one `dragleave` event. This would cause the dropzone to be stuck in the active state. I coun't identify the cuase of the double events, I imagine it is somehow related to layout since another app we have seems to be working fine with seemingly identical components, just differences in how they are laid out / styled.

What this commit does is instead of tracking the number of times a `dragenter` event occurs (once or twice), it instead sets a `_dragInProgress` flag on the first `dragenter` event. Any further `dragenter` events are discarded until a `dragleave` event cancels the drag.

This fixes our app and seems to work in all the browsers I tested. (chrome and firefox).