### PR TITLE
Fix S3 bucket URL generated by the S3Direct ruby class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ class S3Direct
 
   def to_json
     {
-      url: "https://#{@options[:bucket]}.s3.amazonaws.com",
+      url: "https://s3.amazonaws.com/#{@options[:bucket]}",
       credentials: {
         AWSAccessKeyId: @access_key,
         policy:         policy,


### PR DESCRIPTION
This changes the `S3Direct` ruby class documentation to generate the correct URL for the s3 bucket. `https://<bucket name>.s3.amazonaws.com` did not work for me, ``https://s3.amazonaws.com/<bucket name>` does.
