### PR TITLE
Fixed issue when original PlUploader file was lost during error handling of unstarted upload

### DIFF
--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -260,7 +260,7 @@ export default Ember.ArrayProxy.extend({
       if (file == null) {
         file = File.create({
           uploader: uploader,
-          file: file
+          file: error.file
         });
       }
 


### PR DESCRIPTION
Try to set eg. file size limit to 1MB and upload a bigger file. 
Plupload will mark the file as failed and call the `onError` handler. At that stage, the file is not yet in the queue, so a new `pl-upload/File` is created. Yet, the original file is not assigned, and thus it is impossible to show to a user, eg the name of the original file.

This PR sets the correct file.
All tests are still passing.
