### PR TITLE
Removing moxie & plupload js from fastboot build

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,13 @@ module.exports = {
       debugMode = process.env.EMBER_ENV === 'development';
     }
 
-    if (debugMode) {
-      app.import('bower_components/plupload/js/moxie.js');
-      app.import('bower_components/plupload/js/plupload.dev.js');
-    } else {
-      app.import('bower_components/plupload/js/plupload.full.min.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      if (debugMode) {
+        app.import('bower_components/plupload/js/moxie.js');
+        app.import('bower_components/plupload/js/plupload.dev.js');
+      } else {
+        app.import('bower_components/plupload/js/plupload.full.min.js');
+      }
     }
     app.import('bower_components/plupload/js/Moxie.swf', {
       destDir: 'assets'


### PR DESCRIPTION
This merge request fixes #81 

It removes imported files that depend on the DOM from the FastBoot build.