### PR TITLE
Only start uploader when all files have been setup

### DIFF
--- a/addon/system/file.js
+++ b/addon/system/file.js
@@ -159,7 +159,9 @@ export default Ember.Object.extend({
       if (this.file.status === plupload.FAILED) {
         this.file.status = plupload.QUEUED;
       }
-      uploader.start();
+      if (this.get('queue').every((f) => f.settings)) {
+        uploader.start();
+      }
     }
 
     return this._deferred.promise;

--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -138,7 +138,8 @@ export default Ember.ArrayProxy.extend({
     for (let i = 0, len = files.length; i < len; i++) {
       var file = File.create({
         uploader: uploader,
-        file: files[i]
+        file: files[i],
+        queue: this
       });
 
       this.pushObject(file);

--- a/tests/unit/system/file-test.js
+++ b/tests/unit/system/file-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import UploadQueue from 'ember-plupload/system/upload-queue';
+import File from 'ember-plupload/system/file';
+import {
+  module,
+  test
+} from 'qunit';
+
+module('File', {
+});
+
+test("#upload - it will only call its uploader's start method when all queued files have been setup (settings are set on all files)", function(assert) {
+  assert.expect(3);
+  let uploadCalls = 0;
+  const TestableFile = File.extend({
+    upload() {
+      uploadCalls++;
+      return this._super(...arguments);
+    }
+  });
+
+  const uploader = Ember.Object.extend({
+    start() {
+      assert.equal(uploadCalls, 2, 'Uploader was only started after both files were setup');
+    }
+  }).create();
+
+  const fileToUpload1 = {id: 1};
+  const fileToUpload2 = {id: 2};
+  const queue = UploadQueue.create();
+  const file1 = TestableFile.create({uploader, queue, file: fileToUpload1});
+  const file2 = TestableFile.create({uploader, queue, file: fileToUpload2});
+
+  queue.pushObject(file1);
+  queue.pushObject(file2);
+
+  file2.upload('www.example.com');
+  assert.equal(uploadCalls, 1, 'first file called #upload');
+  file1.upload('www.example.com');
+  assert.equal(uploadCalls, 2, 'second file called #upload');
+});


### PR DESCRIPTION
Fixes #84

When uploading muliple files which upload-setup depended on an
async operation (e.g. when obtaining the upload url from a
backend-api) the uploader component contained a race condition
where it assumed that the first file in the plupload uploader
`FilesAdded` callback would also be the first to start uploading.

If that wasn't the case and due to the async nature of obtaining
relevant upload-information one of the files that was queued for
a later upload in plupload was to call its file#upload-method
first the upload of the first file in the queue would fail as it
hadn't completed its setup completely yet.

By making sure that the uploader will only start when all of the
files that should be uploaded have been setup correctly we make
sure that this race condition is no longer an issue.