### PR TITLE
Update plupload and mOxie references

### DIFF
--- a/addon/system/file.js
+++ b/addon/system/file.js
@@ -1,4 +1,4 @@
-/* global mOxie, plupload */
+/* global moxie, plupload */
 import Ember from 'ember';
 
 const get = Ember.get;
@@ -6,8 +6,8 @@ const alias = Ember.computed.alias;
 const reads = Ember.computed.reads;
 
 const RSVP = Ember.RSVP;
-const mOxieFileReader = function () {
-  return new mOxie.FileReader();
+const moxieFileReader = function () {
+  return new moxie.file.FileReader();
 };
 
 const keys = Object.keys;
@@ -169,7 +169,7 @@ export default Ember.Object.extend({
   read(options = { as: 'data-url' }) {
     let file = get(this, 'file').getSource();
     /*jshint -W055 */
-    let reader = mOxieFileReader();
+    let reader = moxieFileReader();
     /*jshint +W055 */
     let { promise, resolve, reject } = RSVP.defer();
     reader.onloadend = resolve;

--- a/addon/system/upload-queue.js
+++ b/addon/system/upload-queue.js
@@ -1,4 +1,4 @@
-/* globals plupload, mOxie */
+/* globals plupload, moxie */
 import Ember from 'ember';
 import File from './file';
 import trim from './trim';
@@ -61,7 +61,7 @@ export default Ember.ArrayProxy.extend({
     get(this, 'queues').pushObject(uploader);
 
     // Set browse_button and drop_element as
-    // references to the buttons so mOxie doesn't
+    // references to the buttons so moxie doesn't
     // get confused when the dom might be detached
     uploader.settings.browse_button = [config.browse_button];
     if (config.drop_element) {
@@ -79,7 +79,7 @@ export default Ember.ArrayProxy.extend({
   runtimeDidChange() {
     let $input = get(this, 'target').$('.moxie-shim input');
     let ruid = $input.attr('id');
-    let I = mOxie.Runtime.getInfo(ruid);
+    let I = moxie.runtime.Runtime.getInfo(ruid);
 
     // Polyfill mobile support
     if (!I.can('summon_file_dialog')) {

--- a/addon/test-helper.js
+++ b/addon/test-helper.js
@@ -1,4 +1,4 @@
-/* global mOxie */
+/* global moxie */
 import Ember from 'ember';
 
 function FakeFile(attrs) {
@@ -52,8 +52,8 @@ FakeFile.prototype = {
   }
 };
 
-mOxie.FileReader = function () {};
-mOxie.FileReader.prototype = {
+moxie.file.FileReader = function () {};
+moxie.file.FileReader.prototype = {
   read(type, source) {
     Ember.assert(`"${source.name}" doesn't have a ${type} for the file to read
 When calling addFiles(), provide the following property:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-plupload",
   "dependencies": {
-    "plupload": "~2.1.8",
+    "plupload": "~2.3.3",
     "dinosheets": "0.1.1"
   }
 }


### PR DESCRIPTION
This PR updates plupload to the latest 2.x.x version available and also updates the references to `mOxie`, which is now just `moxie` (with a lowercase 'o').

This is an attempt to address this issue:
https://github.com/tim-evans/ember-plupload/issues/110