### PR TITLE
fix: update ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.12.0",
     "exists-sync": "^0.0.4",
     "fastboot-transform": "^0.1.0",
     "rsvp": "^4.6.1"


### PR DESCRIPTION
v5 was deprecated